### PR TITLE
Add custom overlay names with default timestamp placeholder name

### DIFF
--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -18,14 +18,9 @@ const ExportEditor = () => {
 
   const saveFile = () => {
     const link = document.createElement( 'a' )
-    link.setAttribute( 'download', 'customTheme.css' )
     link.href = makeCssFile()
-    document.body.appendChild( link )
-    window.requestAnimationFrame( () => {
-      const event = new MouseEvent( 'click' )
-      link.dispatchEvent( event )
-      document.body.removeChild( link )
-    } )
+    link.setAttribute( 'download', 'customTheme.css' )
+    link.click()
   }
 
   const handleClickOpen = () => { setSettings( true ) }

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -44,8 +44,10 @@ const ExportEditor = () => {
         label="Theme Name"
         placeholder={themeName}
         onChange={( { target: { value } } ) => {
-          if ( value.trim() ) setThemeName( `Overlay ${timestamp()}` )
-          setThemeName( value )
+          // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
+          // Else User given string
+          if ( value.trim() === '' ) setThemeName( `Overlay ${timestamp()}` )
+          else setThemeName( value )
         }}
       />
 

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import {
   Box,
   Dialog,
+  TextField,
   DialogTitle,
   DialogActions,
   DialogContent,
@@ -9,17 +10,18 @@ import {
 } from '@material-ui/core'
 
 import makeCssFile from '../../lib/generate'
-import { loadStorage, loadCss } from '../../lib/utils'
+import { loadStorage, loadCss, timestamp } from '../../lib/utils'
 
 import { Button } from '../SettingComponent'
 
 const ExportEditor = () => {
   const [ settings, setSettings ] = useState( false )
+  const [ themeName, setThemeName ] = useState( `Overlay ${timestamp()}` )
 
   const saveFile = () => {
     const link = document.createElement( 'a' )
     link.href = makeCssFile()
-    link.setAttribute( 'download', 'customTheme.css' )
+    link.setAttribute( 'download', `${themeName}.css` )
     link.click()
   }
 
@@ -36,6 +38,17 @@ const ExportEditor = () => {
 
   return (
     <Box p={2}>
+
+      <TextField
+        id="standard-basic"
+        label="Theme Name"
+        placeholder={themeName}
+        onChange={( { target: { value } } ) => {
+          if ( value.trim() ) setThemeName( `Overlay ${timestamp()}` )
+          setThemeName( value )
+        }}
+      />
+
       <Button onClick={saveFile}>
         Save
       </Button>
@@ -79,6 +92,7 @@ const ExportEditor = () => {
           </DialogActions>
 
         </Dialog>
+
       </div>
     </Box>
   )

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -73,3 +73,5 @@ export const loadCss = () => {
       document.documentElement.style.setProperty( storageKey, localStorage[storageKey] )
     ) )
 }
+
+export const timestamp = () => new Date().toISOString().replace( /\.\d{3}\w$/, '' ).replace( 'T', ' ' )


### PR DESCRIPTION
Closes #9 
* [x] need to fix saving with empty spaces (need help ... this has to do with #23?? I 🤔 think so ...will wait for any new changes there) 


This branch is based from https://github.com/saihaj/theme-tool/tree/fix-12 so need to get #23 approved first (so making this draft)