### PR TITLE
Disable opacity for font colors

### DIFF
--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -95,7 +95,7 @@ Button.defaultProps = {
   className: null,
 }
 
-export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, ...props } ) => {
+export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, disableAlpha, ...props } ) => {
   const [ anchorEl, setAnchorEl ] = useState( null )
   const open = Boolean( anchorEl )
   const id = open ? 'simple-popover' : undefined
@@ -137,6 +137,7 @@ export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, .
           className="colorPicker"
           color={value}
           onChange={( { rgb } ) => { onChange( `rgba(${rgb.r},${rgb.g},${rgb.b},${rgb.a})` ) }}
+          disableAlpha={disableAlpha}
           {...props}
         />
 

--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -95,7 +95,7 @@ Button.defaultProps = {
   className: null,
 }
 
-export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, disableAlpha, ...props } ) => {
+export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, ...props } ) => {
   const [ anchorEl, setAnchorEl ] = useState( null )
   const open = Boolean( anchorEl )
   const id = open ? 'simple-popover' : undefined
@@ -137,7 +137,6 @@ export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, d
           className="colorPicker"
           color={value}
           onChange={( { rgb } ) => { onChange( `rgba(${rgb.r},${rgb.g},${rgb.b},${rgb.a})` ) }}
-          disableAlpha={disableAlpha}
           {...props}
         />
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -56,6 +56,7 @@ export const OPTION_TYPES = {
  *   icon: fortawesome icon
  *   storageKey: string
  *   inital: string
+ *   disableAlpha: boolean
  * }
  *
  * Toggle Type schema
@@ -109,13 +110,13 @@ const TEXT_OPTIONS = {
 
   // Font
   primaryFontSize: { name: 'Primary Font Size', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-primary-font-size', units: 'vh', initial: '4.8vh' },
-  primaryFontColor: { name: 'Primary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-font-color', initial: '#ffd22b' },
-  primaryLarivaarAssistColor: { name: 'Primary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-larivaar-assist-color', initial: '#812929' },
-  primaryDropColor: { name: 'Primary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-drop-color', initial: 'none' },
+  primaryFontColor: { name: 'Primary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-font-color', initial: '#ffd22b', disableAlpha: true },
+  primaryLarivaarAssistColor: { name: 'Primary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-larivaar-assist-color', initial: '#812929', disableAlpha: true },
+  primaryDropColor: { name: 'Primary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-drop-color', initial: 'none', disableAlpha: true },
   secondaryFontSize: { name: 'Secondary Font Size', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-secondary-font-size', units: 'vh', initial: 'calc( var(--overlay-primary-font-size) * 0.6 )' },
-  secondaryFontColor: { name: 'Secondary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-font-color', initial: '#FFFFFF' },
-  secondaryLarivaarAssistColor: { name: 'Secondary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-larivaar-assist-color', initial: '#eaffff' },
-  secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-drop-color', initial: 'none' },
+  secondaryFontColor: { name: 'Secondary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-font-color', initial: '#FFFFFF', disableAlpha: true },
+  secondaryLarivaarAssistColor: { name: 'Secondary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-larivaar-assist-color', initial: '#eaffff', disableAlpha: true },
+  secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-drop-color', initial: 'none', disableAlpha: true },
 
   // Vishraam
   vishraamHeavyColor: { name: 'Heavy Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-heavy-color', initial: 'inherit' },


### PR DESCRIPTION
### Summary of PR
Add `disableAlpha` prop type to turn off alpha for color picker

Alpha slider is not shown for the following options in "Text":
* Primary and Secondary 
  * Font Color
  * Larivaar Assist Color
  * Drop Color

**Before**
<img width="236" alt="image" src="https://user-images.githubusercontent.com/44710980/83082144-307fe900-a048-11ea-9d6c-400143bcde12.png">

**After**
<img width="337" alt="image" src="https://user-images.githubusercontent.com/44710980/83082041-e139b880-a047-11ea-9ab2-ebe1d4c17c60.png">


### Tests for unexpected behavior
Colors can be changed with no issues.

### Time spent on PR
15 minutes

### Linked issues
Fix #26 

### Reviewers
@Harjot1Singh @bhajneet 