### PR TITLE
fix: fix overlay padding issues and remove vishraam options

### DIFF
--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -155,11 +155,14 @@ PopoverColorPicker.propTypes = {
   onChange: func.isRequired,
 }
 
+export const SkipRender = () => null
+
 const typeComponents = {
   [OPTION_TYPES.dropdown]: Dropdown,
   [OPTION_TYPES.toggle]: Toggle,
   [OPTION_TYPES.slider]: Slider,
   [OPTION_TYPES.popoverColorPicker]: PopoverColorPicker,
+  [OPTION_TYPES.skipRendering]: SkipRender,
 }
 
 export default type => typeComponents[type]

--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -4,13 +4,13 @@ import {
   any,
   func,
   bool,
-  shape,
   string,
   arrayOf,
   oneOfType,
 } from 'prop-types'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEyeDropper } from '@fortawesome/free-solid-svg-icons'
 
 import {
   Select,
@@ -96,7 +96,7 @@ Button.defaultProps = {
   className: null,
 }
 
-export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, ...props } ) => {
+export const PopoverColorPicker = ( { name, value, storageKey, onChange, ...props } ) => {
   const [ anchorEl, setAnchorEl ] = useState( null )
   const open = Boolean( anchorEl )
   const id = open ? 'simple-popover' : undefined
@@ -113,7 +113,7 @@ export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, .
     <div>
 
       <FontAwesomeIcon
-        icon={icon}
+        icon={faEyeDropper}
         onClick={handleClick}
         size="lg"
         color={value}
@@ -149,7 +149,6 @@ export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, .
 
 PopoverColorPicker.propTypes = {
   value: string.isRequired,
-  icon: shape( {} ).isRequired,
   name: string.isRequired,
   storageKey: string.isRequired,
   onChange: func.isRequired,

--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -154,14 +154,12 @@ PopoverColorPicker.propTypes = {
   onChange: func.isRequired,
 }
 
-export const SkipRender = () => null
 
 const typeComponents = {
   [OPTION_TYPES.dropdown]: Dropdown,
   [OPTION_TYPES.toggle]: Toggle,
   [OPTION_TYPES.slider]: Slider,
   [OPTION_TYPES.popoverColorPicker]: PopoverColorPicker,
-  [OPTION_TYPES.skipRendering]: SkipRender,
 }
 
 export default type => typeComponents[type]

--- a/src/components/SettingComponent.js
+++ b/src/components/SettingComponent.js
@@ -4,6 +4,7 @@ import {
   any,
   func,
   bool,
+  shape,
   string,
   arrayOf,
   oneOfType,
@@ -148,7 +149,7 @@ export const PopoverColorPicker = ( { name, value, icon, storageKey, onChange, .
 
 PopoverColorPicker.propTypes = {
   value: string.isRequired,
-  icon: any.isRequired,
+  icon: shape( {} ).isRequired,
   name: string.isRequired,
   storageKey: string.isRequired,
   onChange: func.isRequired,

--- a/src/components/SettingsMenu.js
+++ b/src/components/SettingsMenu.js
@@ -60,6 +60,8 @@ const EditorPanel = () => {
               const onChange = value => setSettings( { [optionName]: value } )
 
               return (
+                name
+                && (
                 <Box className="option" padding="0.3em 0">
 
                   <Typography className="option-label">{name}</Typography>
@@ -73,6 +75,7 @@ const EditorPanel = () => {
                   />
 
                 </Box>
+                )
               )
             } )}
 

--- a/src/components/SettingsMenu.js
+++ b/src/components/SettingsMenu.js
@@ -59,9 +59,7 @@ const EditorPanel = () => {
               // onChange for any setting
               const onChange = value => setSettings( { [optionName]: value } )
 
-              return (
-                name
-                && (
+              return name && (
                 <Box className="option" padding="0.3em 0">
 
                   <Typography className="option-label">{name}</Typography>
@@ -75,7 +73,6 @@ const EditorPanel = () => {
                   />
 
                 </Box>
-                )
               )
             } )}
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -27,7 +27,6 @@ export const OPTION_TYPES = {
   toggle: Symbol( 'Toggle' ),
   slider: Symbol( 'Slider' ),
   popoverColorPicker: Symbol( 'Popover Color Picker' ),
-  skipRendering: Symbol( 'Skip this option' ),
 }
 
 /**
@@ -89,7 +88,7 @@ const OVERLAY_OPTIONS = {
   flexJustification: { name: 'Justification', type: OPTION_TYPES.dropdown, values: FLEX, storageKey: '--overlay-flex-justification', initial: 'flex-start' },
   height: { name: 'Height', type: OPTION_TYPES.dropdown, values: [ { name: 'Auto', value: 'auto' }, { name: '100', value: '100vh' } ], storageKey: '--overlay-height', initial: 'auto' },
   width: { name: 'Width', type: OPTION_TYPES.slider, min: 1, max: 100, step: 1, storageKey: '--width-slider', initial: '100', units: '%' },
-  overlayWidth: { name: false, type: OPTION_TYPES.skipRendering, storageKey: '--overlay-width', initial: 'calc(var(--width-slider) - 2 * var(--overlay-horizontal-padding))' },
+  overlayWidth: { name: false, storageKey: '--overlay-width', initial: 'calc(var(--width-slider) - 2 * var(--overlay-horizontal-padding))' },
   verticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-vertical-padding', units: 'vh', initial: '0' },
   horizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-horizontal-padding', units: 'vw', initial: '0' },
   backgroundColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-background-color', initial: '#000' },

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -3,7 +3,6 @@ import {
   faSquare,
   faTextWidth,
   faWindowRestore,
-  faEyeDropper,
 } from '@fortawesome/free-solid-svg-icons'
 
 const TEXT_ALIGN = [
@@ -54,7 +53,6 @@ export const OPTION_TYPES = {
  * Color Type schema
  * { name: string
  *   type: symbol
- *   icon: fortawesome icon
  *   storageKey: string
  *   inital: string
  * }
@@ -94,7 +92,7 @@ const OVERLAY_OPTIONS = {
   overlayWidth: { name: false, type: OPTION_TYPES.skipRendering, storageKey: '--overlay-width', initial: 'calc(var(--width-slider) - 2 * var(--overlay-horizontal-padding))' },
   verticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-vertical-padding', units: 'vh', initial: '0' },
   horizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-horizontal-padding', units: 'vw', initial: '0' },
-  backgroundColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-background-color', initial: '#000' },
+  backgroundColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-background-color', initial: '#000' },
   // Need to implement theme-tool#8
   // backgroundSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-background-size', initial: 'cover' },
 }
@@ -103,7 +101,7 @@ const WINDOW_OPTIONS = {
   windowDisplay: { name: 'Display', type: OPTION_TYPES.dropdown, values: [ { name: 'Flex', value: 'flex' }, { name: 'Inline Block', value: 'inline-block' } ], storageKey: '--overlay-window-display', initial: 'flex' },
   windowVerticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-window-vertical-padding', units: 'vh', initial: '0' },
   windowHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-window-horizontal-padding', units: 'vw', initial: '0' },
-  backgroundWindowColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-window-background-color', initial: 'none' },
+  backgroundWindowColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-window-background-color', initial: 'none' },
   // Need to implement theme-tool #8
   // backgroundWindowSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-window-background-size', initial: 'cover' },
 }
@@ -112,25 +110,25 @@ const TEXT_OPTIONS = {
   textAlign: { name: 'Alignment', type: OPTION_TYPES.dropdown, values: TEXT_ALIGN, storageKey: '--overlay-text-align', initial: 'center' },
   textVerticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-text-vertical-padding', units: 'vh', initial: '0' },
   textHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-text-horizontal-padding', units: 'vw', initial: '0' },
-  backgroundTextColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-text-background-color', initial: 'none' },
+  backgroundTextColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-text-background-color', initial: 'none' },
   // Need to implement theme-tool #8
   // backgroundTextSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-text-background-size', initial: 'contain' },
 
   // Font
   primaryFontSize: { name: 'Primary Font Size', type: OPTION_TYPES.slider, min: 2, max: 10, step: 0.01, storageKey: '--overlay-primary-font-size', units: 'vh', initial: '4.8' },
-  primaryFontColor: { name: 'Primary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-font-color', initial: '#ffd22b' },
-  primaryLarivaarAssistColor: { name: 'Primary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-larivaar-assist-color', initial: '#812929' },
-  primaryDropColor: { name: 'Primary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-drop-color', initial: 'none' },
+  primaryFontColor: { name: 'Primary Font Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-primary-font-color', initial: '#ffd22b' },
+  primaryLarivaarAssistColor: { name: 'Primary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-primary-larivaar-assist-color', initial: '#812929' },
+  primaryDropColor: { name: 'Primary Drop Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-primary-drop-color', initial: 'none' },
   secondaryFontSize: { name: 'Secondary Font Size', type: OPTION_TYPES.slider, min: 1, max: 10, step: 0.01, storageKey: '--overlay-secondary-font-size', units: 'vh', initial: '2.88' },
-  secondaryFontColor: { name: 'Secondary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-font-color', initial: '#FFFFFF' },
-  secondaryLarivaarAssistColor: { name: 'Secondary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-larivaar-assist-color', initial: '#eaffff' },
-  secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-drop-color', initial: 'none' },
+  secondaryFontColor: { name: 'Secondary Font Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-secondary-font-color', initial: '#FFFFFF' },
+  secondaryLarivaarAssistColor: { name: 'Secondary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-secondary-larivaar-assist-color', initial: '#eaffff' },
+  secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-secondary-drop-color', initial: 'none' },
 
   // Vishraam
   // Need to be implemented in Desktop first
-  // vishraamHeavyColor: { name: 'Heavy Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-heavy-color', initial: 'inherit' },
-  // vishraamMediumColor: { name: 'Medium Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-medium-color', initial: 'inherit' },
-  // vishraamLightColor: { name: 'Light Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-light-color', initial: 'inherit' },
+  // vishraamHeavyColor: { name: 'Heavy Vishraam Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-vishraam-heavy-color', initial: 'inherit' },
+  // vishraamMediumColor: { name: 'Medium Vishraam Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-vishraam-medium-color', initial: 'inherit' },
+  // vishraamLightColor: { name: 'Light Vishraam Color', type: OPTION_TYPES.popoverColorPicker, storageKey: '--overlay-vishraam-light-color', initial: 'inherit' },
 
 }
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -28,6 +28,7 @@ export const OPTION_TYPES = {
   toggle: Symbol( 'Toggle' ),
   slider: Symbol( 'Slider' ),
   popoverColorPicker: Symbol( 'Popover Color Picker' ),
+  skipRendering: Symbol( 'Skip this option' ),
 }
 
 /**
@@ -66,6 +67,13 @@ export const OPTION_TYPES = {
  *
  * }
  *
+ * Skip Render
+ * { name: false
+ *   type: symbol
+ *   storageKey: string
+ *   intial: any
+ * }
+ *
  */
 
 const PREVIEW_OPTIONS = {
@@ -82,18 +90,19 @@ const PREVIEW_OPTIONS = {
 const OVERLAY_OPTIONS = {
   flexJustification: { name: 'Justification', type: OPTION_TYPES.dropdown, values: FLEX, storageKey: '--overlay-flex-justification', initial: 'flex-start' },
   height: { name: 'Height', type: OPTION_TYPES.dropdown, values: [ { name: 'Auto', value: 'auto' }, { name: '100', value: '100vh' } ], storageKey: '--overlay-height', initial: 'auto' },
-  width: { name: 'Width', type: OPTION_TYPES.slider, min: 10, max: 100, step: 1, storageKey: '--overlay-width', initial: 'inherit', units: 'vw' },
-  verticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 1, max: 10, step: 1, storageKey: '--overlay-vertical-padding', units: 'vh', initial: '2vh' },
-  horizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-horizontal-padding', units: 'vw', initial: 'var(--overlay-vertical-padding)' },
+  width: { name: 'Width', type: OPTION_TYPES.slider, min: 1, max: 100, step: 1, storageKey: '--width-slider', initial: '100', units: '%' },
+  overlayWidth: { name: false, type: OPTION_TYPES.skipRendering, storageKey: '--overlay-width', initial: 'calc(var(--width-slider) - 2 * var(--overlay-horizontal-padding))' },
+  verticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-vertical-padding', units: 'vh', initial: '0' },
+  horizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 1, storageKey: '--overlay-horizontal-padding', units: 'vw', initial: '0' },
   backgroundColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-background-color', initial: '#000' },
-  // Need to implement theme-tool #8
+  // Need to implement theme-tool#8
   // backgroundSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-background-size', initial: 'cover' },
 }
 
 const WINDOW_OPTIONS = {
   windowDisplay: { name: 'Display', type: OPTION_TYPES.dropdown, values: [ { name: 'Flex', value: 'flex' }, { name: 'Inline Block', value: 'inline-block' } ], storageKey: '--overlay-window-display', initial: 'flex' },
   windowVerticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-window-vertical-padding', units: 'vh', initial: '0' },
-  windowHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-window-horizontal-padding', units: 'vw', initial: 'var(--overlay-window-vertical-padding)' },
+  windowHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-window-horizontal-padding', units: 'vw', initial: '0' },
   backgroundWindowColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-window-background-color', initial: 'none' },
   // Need to implement theme-tool #8
   // backgroundWindowSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-window-background-size', initial: 'cover' },
@@ -102,17 +111,17 @@ const WINDOW_OPTIONS = {
 const TEXT_OPTIONS = {
   textAlign: { name: 'Alignment', type: OPTION_TYPES.dropdown, values: TEXT_ALIGN, storageKey: '--overlay-text-align', initial: 'center' },
   textVerticalPadding: { name: 'Vertical Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-text-vertical-padding', units: 'vh', initial: '0' },
-  textHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-text-horizontal-padding', units: 'vw', initial: 'var(--overlay-text-vertical-padding)' },
+  textHorizontalPadding: { name: 'Horizontal Padding', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-text-horizontal-padding', units: 'vw', initial: '0' },
   backgroundTextColor: { name: 'Background Color ', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-text-background-color', initial: 'none' },
   // Need to implement theme-tool #8
   // backgroundTextSize: { name: 'Background Size', type: OPTION_TYPES.dropdown, values: [ { name: 'Cover', value: 'cover' }, { name: 'None', value: 'none' }, { name: 'Contain', value: 'contain' } ], storageKey: '--overlay-text-background-size', initial: 'contain' },
 
   // Font
-  primaryFontSize: { name: 'Primary Font Size', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-primary-font-size', units: 'vh', initial: '4.8vh' },
+  primaryFontSize: { name: 'Primary Font Size', type: OPTION_TYPES.slider, min: 2, max: 10, step: 0.01, storageKey: '--overlay-primary-font-size', units: 'vh', initial: '4.8' },
   primaryFontColor: { name: 'Primary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-font-color', initial: '#ffd22b' },
   primaryLarivaarAssistColor: { name: 'Primary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-larivaar-assist-color', initial: '#812929' },
   primaryDropColor: { name: 'Primary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-primary-drop-color', initial: 'none' },
-  secondaryFontSize: { name: 'Secondary Font Size', type: OPTION_TYPES.slider, min: 0, max: 10, step: 0.1, storageKey: '--overlay-secondary-font-size', units: 'vh', initial: 'calc( var(--overlay-primary-font-size) * 0.6 )' },
+  secondaryFontSize: { name: 'Secondary Font Size', type: OPTION_TYPES.slider, min: 1, max: 10, step: 0.01, storageKey: '--overlay-secondary-font-size', units: 'vh', initial: '2.88' },
   secondaryFontColor: { name: 'Secondary Font Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-font-color', initial: '#FFFFFF' },
   secondaryLarivaarAssistColor: { name: 'Secondary Larivaar Assist Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-larivaar-assist-color', initial: '#eaffff' },
   secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-drop-color', initial: 'none' },

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -118,9 +118,10 @@ const TEXT_OPTIONS = {
   secondaryDropColor: { name: 'Secondary Drop Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-secondary-drop-color', initial: 'none' },
 
   // Vishraam
-  vishraamHeavyColor: { name: 'Heavy Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-heavy-color', initial: 'inherit' },
-  vishraamMediumColor: { name: 'Medium Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-medium-color', initial: 'inherit' },
-  vishraamLightColor: { name: 'Light Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-light-color', initial: 'inherit' },
+  // Need to be implemented in Desktop first
+  // vishraamHeavyColor: { name: 'Heavy Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-heavy-color', initial: 'inherit' },
+  // vishraamMediumColor: { name: 'Medium Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-medium-color', initial: 'inherit' },
+  // vishraamLightColor: { name: 'Light Vishraam Color', type: OPTION_TYPES.popoverColorPicker, icon: faEyeDropper, storageKey: '--overlay-vishraam-light-color', initial: 'inherit' },
 
 }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -59,9 +59,11 @@ export const partitionLine = ( line, strip = true ) => classifyWords( line, stri
 export const loadStorage = () => {
   if ( localStorage.length < Object.keys( OPTIONS ).length ) {
     Object.values( OPTIONS )
-      .forEach( ( { storageKey, initial } ) => (
-        window.localStorage.setItem( storageKey, initial )
-      ) )
+      .forEach( ( { storageKey, initial, units } ) => {
+        if ( units !== undefined ) {
+          window.localStorage.setItem( storageKey, `${initial}${units}` )
+        } else window.localStorage.setItem( storageKey, initial )
+      } )
   }
 }
 


### PR DESCRIPTION
### Summary of PR
Mainly adds a skip render component that allows us to add variables to css by just adding necessary values `options.js`. To allow that, needed to modify the export to css so only necessary values are being exported. 

This was needed so we can use percentage (see the equation below). For more information read the thread on [Slack](https://shabados.slack.com/archives/C013GFL7B0C/p1589406919004300)
> ```calc(var(--width-slider) - 2 * var(--overlay-vertical-padding))```


### Reviewers
@Harjot1Singh 