### PR TITLE
fix: drop color rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import Overlay from './components/Preview'
 import EditorPanel from './components/SettingsMenu'
 
 import { SettingsContext } from './lib/contexts'
-import { loadCss, loadStorage } from './lib/utils'
+import { loadCss, loadStorage, writeCss } from './lib/utils'
 import { OPTIONS } from './lib/options'
 
 import './App.css'
@@ -29,8 +29,7 @@ const App = () => {
   const settingsState = useReducer( ( settings, updatedSettings = {} ) => {
     Object.entries( updatedSettings ).forEach( ( [ name, value ] ) => {
       const { storageKey } = OPTIONS[name]
-
-      if ( storageKey.includes( '--' ) ) document.documentElement.style.setProperty( storageKey, value )
+      writeCss( storageKey, value )
       window.localStorage.setItem( storageKey, value )
     } )
 

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -10,7 +10,7 @@ import {
 } from '@material-ui/core'
 
 import makeCssFile from '../../lib/generate'
-import { loadStorage, loadCss, timestamp } from '../../lib/utils'
+import { timestamp } from '../../lib/utils'
 
 import { Button } from '../SettingComponent'
 
@@ -31,9 +31,8 @@ const ExportEditor = () => {
 
   const resetEditor = () => {
     window.localStorage.clear()
-    loadStorage()
-    loadCss()
     setSettings( false )
+    window.location.reload()
   }
 
   return (

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -155,3 +155,8 @@ export const TABS = [
     icon: faTextWidth,
   },
 ]
+
+export const DROP_COLORS = [
+  OPTIONS.primaryDropColor.storageKey,
+  OPTIONS.secondaryDropColor.storageKey,
+]

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -72,9 +72,8 @@ export const loadStorage = () => {
  */
 const getColorObject = value => {
   if ( [ 'none', 'undefined', null ].includes( value ) ) return null
-  const rgba = value.match( /\d+/g )
-  const rgbaObject = { r: rgba[0], g: rgba[1], b: rgba[2], a: rgba[3] }
-  return rgbaObject
+  const [ r, g, b, a ] = value.match( /\d+/g )
+  return { r, g, b, a }
 }
 
 const writeCssToDom = ( key, value ) => document.documentElement.style.setProperty( key, value )

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -65,13 +65,39 @@ export const loadStorage = () => {
   }
 }
 
+/**
+ * Returns a object with RGBA.
+ * @param {string} value RGBA
+ * https://stackoverflow.com/a/11003212/11321732
+ */
+const getColorObject = value => {
+  if ( [ 'none', 'undefined', null ].includes( value ) ) return null
+  const rgba = value.match( /\d+/g )
+  const rgbaObject = { r: rgba[0], g: rgba[1], b: rgba[2], a: rgba[3] }
+  return rgbaObject
+}
+
+const writeCssToDom = ( key, value ) => document.documentElement.style.setProperty( key, value )
+
+/**
+ * Writes values for CSS to the DOM
+ * @param {string} key CSS variable to update.
+ * @param {string} value new value.
+ */
+export const writeCss = ( key, value ) => {
+  // Drop colors require to be string https://github.com/ShabadOS/desktop/blob/fc01ec563178ad605e42c2274b030da366063a13/app/frontend/src/Overlay/themes/Example.template#L82
+  if ( key.includes( 'drop' ) ) {
+    const rgba = getColorObject( value )
+    if ( rgba === null ) writeCssToDom( key, value )
+    else writeCssToDom( key, `${rgba.r}, ${rgba.g}, ${rgba.b}` )
+  } else writeCssToDom( key, localStorage[key] )
+}
+
 // Load stylesheet from local storage
 export const loadCss = () => {
   Object.values( OPTIONS )
     .filter( ( { storageKey } ) => storageKey.includes( '--' ) )
-    .forEach( ( { storageKey } ) => (
-      document.documentElement.style.setProperty( storageKey, localStorage[storageKey] )
-    ) )
+    .forEach( ( { storageKey } ) => writeCss( storageKey, localStorage[storageKey] ) )
 }
 
 export const timestamp = () => new Date().toISOString().replace( /\.\d{3}\w$/, '' ).replace( 'T', ' ' )

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -88,7 +88,9 @@ export const writeCss = ( key, value ) => {
   if ( DROP_COLORS.includes( key ) ) {
     const rgba = getColorObject( value )
     writeCssToDom( key, rgba ? `${rgba.r}, ${rgba.g}, ${rgba.b}` : value )
-  } else writeCssToDom( key, localStorage[key] )
+    return
+  }
+  writeCssToDom( key, localStorage[key] )
 }
 
 // Load stylesheet from local storage

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,7 +2,7 @@
  * https://github.com/ShabadOS/desktop/blob/dev/app/frontend/src/lib/utils.js
  */
 
-import { OPTIONS } from './options'
+import { OPTIONS, DROP_COLORS } from './options'
 
 // Detect vishraams/pauses with characters
 export const PAUSE_CHARS = {
@@ -85,10 +85,9 @@ const writeCssToDom = ( key, value ) => document.documentElement.style.setProper
  */
 export const writeCss = ( key, value ) => {
   // Drop colors require to be string https://github.com/ShabadOS/desktop/blob/fc01ec563178ad605e42c2274b030da366063a13/app/frontend/src/Overlay/themes/Example.template#L82
-  if ( key.includes( 'drop' ) ) {
+  if ( DROP_COLORS.includes( key ) ) {
     const rgba = getColorObject( value )
-    if ( rgba === null ) writeCssToDom( key, value )
-    else writeCssToDom( key, `${rgba.r}, ${rgba.g}, ${rgba.b}` )
+    writeCssToDom( key, rgba ? `${rgba.r}, ${rgba.g}, ${rgba.b}` : value )
   } else writeCssToDom( key, localStorage[key] )
 }
 


### PR DESCRIPTION
### Summary of PR
* Drop colors now get rendered as required in desktop. 
* Refactors to write CSS in a function that can be exported and use in multiple places. 
* Fixes reset to default

### Tests for unexpected behavior
Before: Dropdown colors were not working.
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/44710980/83359738-c7e38580-a341-11ea-9ade-d5b0ba380d96.png">

After: 
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/44710980/83359712-a6829980-a341-11ea-91fb-376474e8f1d5.png">


### Time spent on PR
2 hours

### Linked issues
Fix #16 

### Reviewers
@Harjot1Singh 