### PR TITLE
fix: use timestamp as default value

### DIFF
--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -42,7 +42,7 @@ const ExportEditor = () => {
         id="standard-basic"
         label="Theme Name"
         defaultValue={themeName}
-        onClick={( { target } ) => target.select()}
+        onFocus={( { target } ) => target.select()}
         onChange={( { target: { value } } ) => {
           // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
           // Else User given string

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -41,13 +41,15 @@ const ExportEditor = () => {
       <TextField
         id="standard-basic"
         label="Theme Name"
-        placeholder={themeName}
+        defaultValue={themeName}
+        onClick={( { target } ) => target.select()}
         onChange={( { target: { value } } ) => {
           // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
           // Else User given string
           if ( value.trim() === '' ) setThemeName( `Overlay ${timestamp()}` )
           else setThemeName( value )
         }}
+        fullWidth
       />
 
       <Button onClick={saveFile}>


### PR DESCRIPTION
### Summary of PR
Set the default value in name field as the timestamp (instead of placeholder) and when focused it will select all the text

### Preview
https://shabad-os-theme-tool-git-saihaj-issue42.saihaj.now.sh/

### Time spent on PR
15mins

### Linked issues
Fixes #42

### Reviewers
@bhajneet @Harjot1Singh 