### PR TITLE
fix: export tab styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ const darkTheme = createMuiTheme( {
       main: '#DCCDA2',
     },
     secondary: {
-      main: '#DCCDA2',
+      main: '#693E4B',
     },
   },
   contrastThreshold: 3,

--- a/src/components/EditorPanel.js
+++ b/src/components/EditorPanel.js
@@ -57,19 +57,18 @@ const EditorPanel = () => {
 
       </Tabs>
 
-      <Suspense fallback={<div>loading...</div>}>
-        {tabName === 'Export' && <ExportEditor />}
-      </Suspense>
+      <ThemeProvider theme={lightTheme}>
 
-      {TABS
-        .filter( ( { name } ) => name === tabName )
-        .map( ( { options } ) => (
+        <Suspense fallback={<div>loading...</div>}>
+          {tabName === 'Export' && <ExportEditor />}
+        </Suspense>
 
-          <ThemeProvider key={options} theme={lightTheme}>
-            <Box className="pane" p={2}>
-
+        {TABS
+          .filter( ( { name } ) => name === tabName )
+          .map( ( { name: tab, options } ) => (
+            <Box key={tab} className="pane" p={2}>
               {options.map( optionName => {
-                // Grab the actual option
+              // Grab the actual option
                 const { name, type, storageKey, ...props } = OPTIONS[optionName]
 
                 // Get the component for the given type
@@ -96,8 +95,9 @@ const EditorPanel = () => {
               } )}
 
             </Box>
-          </ThemeProvider>
-        ) )}
+          ) )}
+
+      </ThemeProvider>
 
     </div>
   )

--- a/src/components/editors/ExportEditor.css
+++ b/src/components/editors/ExportEditor.css
@@ -1,7 +1,7 @@
 .option .save-text-input .MuiInput-underline:before {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.87);
+  border-bottom: 1px solid #693E4B;
 }
 
 .option .save-text-input .MuiFormLabel-root, .MuiInput-input {
-  color: rgba(0, 0, 0, 0.87);
+  color: #693E4B;
 }

--- a/src/components/editors/ExportEditor.css
+++ b/src/components/editors/ExportEditor.css
@@ -1,0 +1,7 @@
+.option .save-text-input .MuiInput-underline:before {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.87);
+}
+
+.option .save-text-input .MuiFormLabel-root, .MuiInput-input {
+  color: rgba(0, 0, 0, 0.87);
+}

--- a/src/components/editors/ExportEditor.css
+++ b/src/components/editors/ExportEditor.css
@@ -1,7 +1,0 @@
-.option .text-input .MuiInput-underline:before {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.7);
-}
-
-.option .text-input .MuiFormLabel-root:not(.Mui-focused), .option .text-input .MuiInput-input {
-  color: rgba(0, 0, 0, 0.7);
-}

--- a/src/components/editors/ExportEditor.css
+++ b/src/components/editors/ExportEditor.css
@@ -1,7 +1,7 @@
-.option .save-text-input .MuiInput-underline:before {
-  border-bottom: 1px solid #693E4B;
+.option .text-input .MuiInput-underline:before {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.7);
 }
 
-.option .save-text-input .MuiFormLabel-root, .MuiInput-input {
-  color: #693E4B;
+.option .text-input .MuiFormLabel-root:not(.Mui-focused), .option .text-input .MuiInput-input {
+  color: rgba(0, 0, 0, 0.7);
 }

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -43,9 +43,10 @@ const ExportEditor = () => {
       <div className="option">
 
         <TextField
-          className="save-text-input"
-          id="standard-basic"
+          className="text-input"
           label="Theme Name"
+          color="secondary"
+          InputProps={{ color: 'secondary' }}
           placeholder={themeName}
           onChange={( { target: { value } } ) => {
             // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -14,6 +14,8 @@ import { timestamp } from '../../lib/utils'
 
 import { Button } from '../SettingComponent'
 
+import './ExportEditor.css'
+
 const ExportEditor = () => {
   const [ settings, setSettings ] = useState( false )
   const [ themeName, setThemeName ] = useState( `Overlay ${timestamp()}` )
@@ -36,27 +38,34 @@ const ExportEditor = () => {
   }
 
   return (
-    <Box p={2}>
+    <Box className="pane" p={2}>
 
-      <TextField
-        id="standard-basic"
-        label="Theme Name"
-        placeholder={themeName}
-        onChange={( { target: { value } } ) => {
-          // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
-          // Else User given string
-          if ( value.trim() === '' ) setThemeName( `Overlay ${timestamp()}` )
-          else setThemeName( value )
-        }}
-      />
+      <div className="option">
 
-      <Button onClick={saveFile}>
-        Save
-      </Button>
+        <TextField
+          className="save-text-input"
+          id="standard-basic"
+          label="Theme Name"
+          placeholder={themeName}
+          onChange={( { target: { value } } ) => {
+            // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
+            // Else User given string
+            if ( value.trim() === '' ) setThemeName( `Overlay ${timestamp()}` )
+            else setThemeName( value )
+          }}
+        />
 
-      <div>
+      </div>
 
-        <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+      <div className="option">
+        <Button color="primary" onClick={saveFile} className="option-label">
+          Save
+        </Button>
+      </div>
+
+      <div className="option">
+
+        <Button color="primary" onClick={handleClickOpen} className="option-label">
           Reset to defaults
         </Button>
 
@@ -66,7 +75,6 @@ const ExportEditor = () => {
           aria-labelledby="alert-dialog-title"
           aria-describedby="alert-dialog-description"
         >
-
 
           <DialogTitle id="alert-dialog-title">
             Are you sure you want to reset the theme editor?
@@ -93,8 +101,8 @@ const ExportEditor = () => {
           </DialogActions>
 
         </Dialog>
-
       </div>
+
     </Box>
   )
 }

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -14,8 +14,6 @@ import { timestamp } from '../../lib/utils'
 
 import { Button } from '../SettingComponent'
 
-import './ExportEditor.css'
-
 const ExportEditor = () => {
   const [ settings, setSettings ] = useState( false )
   const [ themeName, setThemeName ] = useState( `Overlay ${timestamp()}` )
@@ -45,8 +43,6 @@ const ExportEditor = () => {
         <TextField
           className="text-input"
           label="Theme Name"
-          color="secondary"
-          InputProps={{ color: 'secondary' }}
           defaultValue={themeName}
           onFocus={( { target } ) => target.select()}
           onChange={( { target: { value } } ) => {
@@ -61,14 +57,14 @@ const ExportEditor = () => {
       </div>
 
       <div className="option">
-        <Button color="secondary" onClick={saveFile}>
+        <Button color="primary" onClick={saveFile}>
           Save
         </Button>
       </div>
 
       <div className="option">
 
-        <Button color="secondary" onClick={handleClickOpen}>
+        <Button color="primary" onClick={handleClickOpen}>
           Reset to defaults
         </Button>
 

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -47,13 +47,15 @@ const ExportEditor = () => {
           label="Theme Name"
           color="secondary"
           InputProps={{ color: 'secondary' }}
-          placeholder={themeName}
+          defaultValue={themeName}
+          onFocus={( { target } ) => target.select()}
           onChange={( { target: { value } } ) => {
             // Empty string then set default (Overlay 2020-05-21 HH_MM_SS)
             // Else User given string
             if ( value.trim() === '' ) setThemeName( `Overlay ${timestamp()}` )
             else setThemeName( value )
           }}
+          fullWidth
         />
 
       </div>

--- a/src/components/editors/ExportEditor.js
+++ b/src/components/editors/ExportEditor.js
@@ -58,14 +58,14 @@ const ExportEditor = () => {
       </div>
 
       <div className="option">
-        <Button color="primary" onClick={saveFile} className="option-label">
+        <Button color="secondary" onClick={saveFile}>
           Save
         </Button>
       </div>
 
       <div className="option">
 
-        <Button color="primary" onClick={handleClickOpen} className="option-label">
+        <Button color="secondary" onClick={handleClickOpen}>
           Reset to defaults
         </Button>
 
@@ -90,7 +90,7 @@ const ExportEditor = () => {
 
           <DialogActions>
 
-            <Button onClick={resetEditor} color="secondary">
+            <Button onClick={resetEditor} color="primary">
               Reset
             </Button>
 


### PR DESCRIPTION
### Summary of PR
Add class names to export tab to use the theme defaults. Added styles for the input box since the theme styles used by it are too light so needed to override those. Update the secondary theme color to purple color instead of it being the same as primary. 

### Tests for unexpected behavior
**After:**
![image](https://user-images.githubusercontent.com/44710980/84174393-2e545c00-aa44-11ea-952a-a34c37b875ec.png)


Preview link: https://shabad-os-theme-tool-git-saihaj-issue41.saihaj.now.sh/

### Time spent on PR
60 minutes

### Linked issues
Fix #41 

### Reviewers
@bhajneet @Harjot1Singh 