### PR TITLE
ci: improve caching in gh-workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,17 @@ jobs:
           node-version: 12.x
 
       - name: Cache Node.js modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
+        id: cache
         with:
-          path: ~/.npm
+          path: ./node_modules
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
 
       - name: Install npm dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm i
 
       - name: Run Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,14 @@ jobs:
         uses: actions/cache@v2
         id: cache
         with:
-          path: ./node_modules
+          path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
 
       - name: Install npm dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm i
+        run: npm ci
 
       - name: Run Build
         run: npm run build


### PR DESCRIPTION
### Summary of PR
`node_modules` directory should be cached and restored. If it was restored then we can skip `npm i`

### Tests for unexpected behavior
Will probably need to see in future workflows. Personally don't think quite useful for this workflow since this is deploy action and not something used on regular basis, so we will probably end up installing modules anyway because [GitHub evicts caches that are not accessed in over 7 days ](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy). But we can use this in future workflows that will be used often like linting or tests.

Update: If I read through the GitHub cache action [docs](https://github.com/actions/cache/blob/master/examples.md#node---npm) they say:
> > Note: It is not recommended to cache node_modules, as it can break across Node versions and won't work with npm ci

But I don't understand why cache `~/.npm` since it doesn't really make it fast, only caching `node_modules` speeds up the process : ) and if there are changes to `package-lock` we will download new version of everything

### Time spent on PR
nine_thousand_years : )

### Linked issues
Fixes #22

### Reviewers
@Harjot1Singh 