### PR TITLE
fix: apply vh-factor to overlay height in preview

### DIFF
--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -5,7 +5,7 @@
 .overlay {
   padding: calc( var(--overlay-vertical-padding) * var(--vh-factor) ) calc( var(--overlay-horizontal-padding) * var(--vw-factor) );
   display: var(--overlay-window-display);
-  height: var(--overlay-height);
+  height: calc( var(--overlay-height) * var(--vh-factor) );
   width: var(--overlay-width);
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
### Summary of PR
Setting "Height" to "100" does not apply the scaling factor to the preview box, resulting in vertical justifications of `middle` and `bottom` to shoot off the screen. 

This PR applies the factor, resolving this.

### Tests for unexpected behavior
- Toggled the different settings

### Time spent on PR
- 3 minutes

### Linked issues
Closes #40

### Reviewers
@bhajneet @saihaj 