### PR TITLE
fix: drop color exporting issue

### DIFF
--- a/src/lib/generate.js
+++ b/src/lib/generate.js
@@ -1,4 +1,5 @@
-import { OPTIONS } from './options'
+import { OPTIONS, DROP_COLORS } from './options'
+import { getColorObject } from './utils'
 
 let generateFile = null
 
@@ -14,7 +15,14 @@ const getData = () => [
     .filter( ( { storageKey } ) => storageKey.includes( '--' ) )
     .filter( ( { storageKey } ) => localStorage[storageKey] !== 'none' )
     .filter( ( { storageKey } ) => localStorage[storageKey] !== 'inherit' )
-    .map( ( { storageKey } ) => ( `${storageKey}: ${localStorage[storageKey]};\n` ) ),
+    .map( ( { storageKey } ) => {
+      // Drop colors require to be string https://github.com/ShabadOS/desktop/blob/fc01ec563178ad605e42c2274b030da366063a13/app/frontend/src/Overlay/themes/Example.template#L82
+      if ( DROP_COLORS.includes( storageKey ) ) {
+        const rgba = getColorObject( localStorage[storageKey] )
+        return `${storageKey}: ${rgba.r}, ${rgba.g}, ${rgba.b};\n`
+      }
+      return `${storageKey}: ${localStorage[storageKey]};\n`
+    } ),
   '}',
 ]
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -72,7 +72,7 @@ export const loadStorage = () => {
  * @param {string} value RGBA
  * https://stackoverflow.com/a/11003212/11321732
  */
-const getColorObject = value => {
+export const getColorObject = value => {
   if ( [ 'none', 'undefined', null ].includes( value ) ) return null
   const [ r, g, b, a ] = value.match( /\d+/g )
   return { r, g, b, a }


### PR DESCRIPTION
### Summary of PR
Drop colors need to be string when exported (desktop requires it)

### Tests for unexpected behavior
Before: 
`--overlay-primary-drop-color: rgba(19,49,255,1);`

After:
`--overlay-primary-drop-color: 19, 49, 255;`

![image](https://user-images.githubusercontent.com/44710980/84940157-08166800-b0a5-11ea-9398-2894eb384956.png)
### Time spent on PR
30 mins

**Preview:** https://shabad-os-theme-tool-git-saihaj-issue49.saihaj.vercel.app

### Linked issues
Fixes #49

### Reviewers
@Harjot1Singh 